### PR TITLE
Fix constructor parameter formatting in CreateFrontendNotesTable

### DIFF
--- a/Setup/Patch/Schema/CreateFrontendNotesTable.php
+++ b/Setup/Patch/Schema/CreateFrontendNotesTable.php
@@ -20,7 +20,7 @@ class CreateFrontendNotesTable implements SchemaPatchInterface
      * @param SchemaSetupInterface $schemaSetup
      */
     public function __construct(
-        SchemaSetupInterface $schemaSetup,
+        SchemaSetupInterface $schemaSetup
     ) {
         $this->schemaSetup = $schemaSetup;
     }


### PR DESCRIPTION
PHP Parse error:  syntax error, unexpected ')', expecting variable (T_VARIABLE) in ./vendor/alekseon/custom-forms-builder/Setup/Patch/Schema/CreateFrontendNotesTable.php on line 24 while setup:upgrade